### PR TITLE
Filter shown ports for selection 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pioarduino-ide",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "icon": "assets/images/pioarduino-128x128.png",
   "publisher": "pioarduino",
   "engines": {

--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -339,6 +339,10 @@ export default class ProjectTaskManager {
       serialPorts = serialPorts.filter(
         (port) => !/\/(ttyS\d|rfcomm)/.test(port.port),
       );
+    } else if (process.platform === 'win32') {
+      serialPorts = serialPorts.filter(
+        (port) => !/bluetooth/i.test(port.description || ''),
+      );
     }
     const pickedItem = await vscode.window.showQuickPick(
       [

--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -331,9 +331,7 @@ export default class ProjectTaskManager {
     let serialPorts = await listCoreSerialPorts();
     if (process.platform === 'darwin') {
       serialPorts = serialPorts.filter(
-        (port) =>
-          !/bluetooth|debug/i.test(port.port) &&
-          !/bluetooth|debug/i.test(port.description || ''),
+        (port) => !/\.(Bluetooth|debug)/i.test(port.port),
       );
     } else if (process.platform === 'linux') {
       serialPorts = serialPorts.filter(

--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -335,6 +335,10 @@ export default class ProjectTaskManager {
           !/bluetooth|debug/i.test(port.port) &&
           !/bluetooth|debug/i.test(port.description || ''),
       );
+    } else if (process.platform === 'linux') {
+      serialPorts = serialPorts.filter(
+        (port) => !/\/(ttyS\d|rfcomm)/.test(port.port),
+      );
     }
     const pickedItem = await vscode.window.showQuickPick(
       [

--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -328,7 +328,14 @@ export default class ProjectTaskManager {
   }
 
   async pickProjectPort() {
-    const serialPorts = await listCoreSerialPorts();
+    let serialPorts = await listCoreSerialPorts();
+    if (process.platform === 'darwin') {
+      serialPorts = serialPorts.filter(
+        (port) =>
+          !/bluetooth|debug/i.test(port.port) &&
+          !/bluetooth|debug/i.test(port.description || ''),
+      );
+    }
     const pickedItem = await vscode.window.showQuickPick(
       [
         { label: 'Auto' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleaner serial-port chooser: irrelevant Bluetooth, debug and certain virtual ports are now filtered out on macOS, Linux, and Windows so the list shows only relevant options and “Auto”/“Custom...” selections behave as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->