### PR TITLE
Use selected VSC port for Filesystem upload and Flash erase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pioarduino-ide",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "icon": "assets/images/pioarduino-128x128.png",
   "publisher": "pioarduino",
   "engines": {

--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -339,6 +339,10 @@ export default class ProjectTaskManager {
       serialPorts = serialPorts.filter(
         (port) => !/\/(ttyS\d|rfcomm)/.test(port.port),
       );
+    } else if (process.platform === 'win32') {
+      serialPorts = serialPorts.filter(
+        (port) => !/bluetooth/i.test(port.description || ''),
+      );
     }
     const pickedItem = await vscode.window.showQuickPick(
       [

--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -7,7 +7,7 @@
  */
 
 import { IS_WINDOWS, STATUS_BAR_PRIORITY_START } from '../constants';
-import { disposeSubscriptions, listCoreSerialPorts } from '../utils';
+import { disposeSubscriptions, listCoreSerialPorts, notifyError } from '../utils';
 import { getProjectItemState, updateProjectItemState } from './helpers';
 import ProjectTasksTreeProvider from './task-tree';
 import { extension } from '../main';
@@ -176,7 +176,7 @@ export default class ProjectTaskManager {
       try {
         await extension.fireWillUpload(this._customPort);
       } catch (err) {
-        utils.notifyError('Upload Port Coordination', err);
+        notifyError('Upload Port Coordination', err);
         return;
       }
       // Set ownership only for real uploads so that fireDidUpload is emitted
@@ -373,7 +373,7 @@ export default class ProjectTaskManager {
       );
     } else if (process.platform === 'linux') {
       serialPorts = serialPorts.filter(
-        (port) => !/\/(ttyS\d|rfcomm)/.test(port.port),
+        (port) => !/\/(ttyS\d+|rfcomm)/.test(port.port),
       );
     } else if (process.platform === 'win32') {
       serialPorts = serialPorts.filter(

--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -124,6 +124,17 @@ export default class ProjectTaskManager {
       envClone.PATH = process.env.PLATFORMIO_PATH;
       envClone.Path = process.env.PLATFORMIO_PATH;
     }
+    // getCoreArgs only appends --upload-port when the TaskItem declares
+    // optionalArgs. Dynamically fetched targets (uploadfs, erase_flash, …)
+    // have no optionalArgs, so we append the port ourselves when needed.
+    let coreArgs = projectTask.getCoreArgs({ port: this._customPort });
+    if (this._customPort && !coreArgs.includes('--upload-port')) {
+      const targetIdx = coreArgs.indexOf('--target');
+      if (targetIdx !== -1 && /^(upload|erase)/i.test(coreArgs[targetIdx + 1] ?? '')) {
+        coreArgs = [...coreArgs, '--upload-port', this._customPort];
+      }
+    }
+
     const vscodeTask = new vscode.Task(
       {
         type: ProjectTaskManager.PROVIDER_TYPE,
@@ -134,7 +145,7 @@ export default class ProjectTaskManager {
       ProjectTaskManager.PROVIDER_TYPE,
       new vscode.ProcessExecution(
         IS_WINDOWS ? 'platformio.exe' : 'platformio',
-        projectTask.getCoreArgs({ port: this._customPort }),
+        coreArgs,
         {
           cwd: this.projectDir,
           env: envClone,
@@ -268,7 +279,11 @@ export default class ProjectTaskManager {
 
   _isUploadTask(task) {
     const args = this.getTaskArgs(task);
-    return args.includes('upload');
+    if (args.includes('upload')) {
+      return true;
+    }
+    const targetIdx = args.indexOf('--target');
+    return targetIdx !== -1 && /^upload/i.test(args[targetIdx + 1] ?? '');
   }
 
   areTasksEqual(task1, task2) {

--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -170,22 +170,24 @@ export default class ProjectTaskManager {
   async runTask(task) {
     this._autoCloseSerialMonitor(task);
 
-    // Fire onWillUpload event for upload tasks and wait until all subscribers
+    // Wait for all port-owning tasks (upload*, erase*) until all subscribers
     // (e.g. ESP-Decoder) have released the serial port before starting the task.
-    if (this._isUploadTask(task)) {
+    if (this._needsPortCoordinationTask(task)) {
       try {
         await extension.fireWillUpload(this._customPort);
       } catch (err) {
         utils.notifyError('Upload Port Coordination', err);
         return;
       }
-      // Set ownership only after coordination succeeds and the task is launched,
-      // so a fireWillUpload rejection leaves _ownedUploadTaskId unset.
+      // Set ownership only for real uploads so that fireDidUpload is emitted
+      // on completion. Erase tasks do not emit upload lifecycle events.
       await vscode.commands.executeCommand(
         'workbench.action.tasks.runTask',
         `${ProjectTaskManager.PROVIDER_TYPE}: ${task.id}`,
       );
-      this._ownedUploadTaskId = task.id;
+      if (this._isUploadTask(task)) {
+        this._ownedUploadTaskId = task.id;
+      }
       return;
     }
 
@@ -202,8 +204,7 @@ export default class ProjectTaskManager {
     const startedArgs = this.getTaskArgs(this._startedTask);
     const closeMonitorConds = [
       extension.getConfiguration('autoCloseSerialMonitor'),
-      ['upload', 'test'].some((arg) => startedArgs.includes(arg)) ||
-        ProjectTaskManager._isPortOwningTarget(this._getTarget(startedArgs)),
+      startedArgs.includes('test') || this._needsPortCoordinationTask(this._startedTask),
     ];
     if (!closeMonitorConds.every((value) => value)) {
       return;
@@ -287,11 +288,24 @@ export default class ProjectTaskManager {
     return idx !== -1 ? args[idx + 1] : undefined;
   }
 
-  _isUploadTask(task) {
+  // Returns true for any task that needs exclusive port access: upload* and
+  // erase* targets. Used for port coordination and serial monitor auto-close.
+  _needsPortCoordinationTask(task) {
     const args = this.getTaskArgs(task);
     return (
       args.includes('upload') ||
       ProjectTaskManager._isPortOwningTarget(this._getTarget(args))
+    );
+  }
+
+  // Returns true only for real upload tasks (upload, uploadfs, …).
+  // Erase tasks are intentionally excluded so upload lifecycle events
+  // (fireWillUpload / fireDidUpload) are not emitted for erase operations.
+  _isUploadTask(task) {
+    const args = this.getTaskArgs(task);
+    return (
+      args.includes('upload') ||
+      /^upload/i.test(this._getTarget(args) ?? '')
     );
   }
 

--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -331,9 +331,7 @@ export default class ProjectTaskManager {
     let serialPorts = await listCoreSerialPorts();
     if (process.platform === 'darwin') {
       serialPorts = serialPorts.filter(
-        (port) =>
-          !/bluetooth|debug/i.test(port.port) &&
-          !/bluetooth|debug/i.test(port.description || ''),
+        (port) => !/\.(Bluetooth|debug)/i.test(port.port),
       );
     } else if (process.platform === 'linux') {
       serialPorts = serialPorts.filter(

--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -335,6 +335,10 @@ export default class ProjectTaskManager {
           !/bluetooth|debug/i.test(port.port) &&
           !/bluetooth|debug/i.test(port.description || ''),
       );
+    } else if (process.platform === 'linux') {
+      serialPorts = serialPorts.filter(
+        (port) => !/\/(ttyS\d|rfcomm)/.test(port.port),
+      );
     }
     const pickedItem = await vscode.window.showQuickPick(
       [

--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -128,11 +128,12 @@ export default class ProjectTaskManager {
     // optionalArgs. Dynamically fetched targets (uploadfs, erase_flash, …)
     // have no optionalArgs, so we append the port ourselves when needed.
     let coreArgs = projectTask.getCoreArgs({ port: this._customPort });
-    if (this._customPort && !coreArgs.includes('--upload-port')) {
-      const targetIdx = coreArgs.indexOf('--target');
-      if (targetIdx !== -1 && /^(upload|erase)/i.test(coreArgs[targetIdx + 1] ?? '')) {
-        coreArgs = [...coreArgs, '--upload-port', this._customPort];
-      }
+    if (
+      this._customPort &&
+      !coreArgs.includes('--upload-port') &&
+      ProjectTaskManager._isPortOwningTarget(this._getTarget(coreArgs))
+    ) {
+      coreArgs = [...coreArgs, '--upload-port', this._customPort];
     }
 
     const vscodeTask = new vscode.Task(
@@ -198,11 +199,11 @@ export default class ProjectTaskManager {
   async _autoCloseSerialMonitor(startedTask) {
     this._startedTask = startedTask;
     this._tasksToRestore = [];
+    const startedArgs = this.getTaskArgs(this._startedTask);
     const closeMonitorConds = [
       extension.getConfiguration('autoCloseSerialMonitor'),
-      ['upload', 'test'].some((arg) =>
-        this.getTaskArgs(this._startedTask).includes(arg),
-      ),
+      ['upload', 'test'].some((arg) => startedArgs.includes(arg)) ||
+        ProjectTaskManager._isPortOwningTarget(this._getTarget(startedArgs)),
     ];
     if (!closeMonitorConds.every((value) => value)) {
       return;
@@ -277,13 +278,21 @@ export default class ProjectTaskManager {
     return ['--target', 'upload', 'monitor'].every((arg) => args.includes(arg));
   }
 
+  static _isPortOwningTarget(target) {
+    return /^(upload|erase)/i.test(target ?? '');
+  }
+
+  _getTarget(args) {
+    const idx = args.indexOf('--target');
+    return idx !== -1 ? args[idx + 1] : undefined;
+  }
+
   _isUploadTask(task) {
     const args = this.getTaskArgs(task);
-    if (args.includes('upload')) {
-      return true;
-    }
-    const targetIdx = args.indexOf('--target');
-    return targetIdx !== -1 && /^upload/i.test(args[targetIdx + 1] ?? '');
+    return (
+      args.includes('upload') ||
+      ProjectTaskManager._isPortOwningTarget(this._getTarget(args))
+    );
   }
 
   areTasksEqual(task1, task2) {

--- a/src/project/tasks.js
+++ b/src/project/tasks.js
@@ -328,7 +328,14 @@ export default class ProjectTaskManager {
   }
 
   async pickProjectPort() {
-    const serialPorts = await listCoreSerialPorts();
+    let serialPorts = await listCoreSerialPorts();
+    if (process.platform === 'darwin') {
+      serialPorts = serialPorts.filter(
+        (port) =>
+          !/bluetooth|debug/i.test(port.port) &&
+          !/bluetooth|debug/i.test(port.description || ''),
+      );
+    }
     const pickedItem = await vscode.window.showQuickPick(
       [
         { label: 'Auto' },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial port selection by filtering likely-irrelevant ports (Bluetooth, debug, virtual) on macOS, Linux, and Windows.
  * More reliable handling of upload/erase tasks: port coordination now covers port-owning tasks, upload lifecycle no longer impacted by erase tasks, and serial monitor auto-close behavior updated.
  * Custom upload port is now correctly applied during task execution.

* **Chores**
  * Extension version bumped to 1.3.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->