### PR TITLE
fix: remember choosen setting for cpptools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the **pioarduino IDE** VSCode extension are documented in
 
 ---
 
+## [1.3.10] - 2026-04-17
+
+### 🐛 Bug Fixes
+
+- **Conflicted extensions warning shown only once** — the warning about conflicting IntelliSense extensions (e.g. cpptools) is now persisted via global state so it no longer appears on every VS Code restart. The warning is permanently dismissed after the user uninstalls the conflicted extensions; clicking "More details" or "Remind later" will still allow it to reappear next session.
+
+---
+
 ## [1.3.9] - 2026-04-17
 
 ### 🐛 Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pioarduino-ide",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "icon": "assets/images/pioarduino-128x128.png",
   "publisher": "pioarduino",
   "engines": {

--- a/src/misc.js
+++ b/src/misc.js
@@ -56,6 +56,12 @@ export async function maybeRateExtension() {
 }
 
 export async function warnAboutConflictedExtensions() {
+  const stateKey = 'conflicted-extensions-warned';
+  const state = extension.context.globalState.get(stateKey);
+  if (state && state.done) {
+    return;
+  }
+
   const conflictedIds = getActiveConflictedExtensionIds();
   const conflicted = vscode.extensions.all.filter(
     (ext) => ext.isActive && conflictedIds.includes(ext.id),
@@ -79,6 +85,7 @@ export async function warnAboutConflictedExtensions() {
         'vscode.open',
         vscode.Uri.parse('http://bit.ly/pio-vscode-conflicted-extensions'),
       );
+      extension.context.globalState.update(stateKey, { done: true });
       break;
     case 'Uninstall conflicted':
       conflicted.forEach((ext) => {
@@ -87,7 +94,11 @@ export async function warnAboutConflictedExtensions() {
           ext.id,
         );
       });
+      extension.context.globalState.update(stateKey, { done: true });
       vscode.commands.executeCommand('workbench.action.reloadWindow');
+      break;
+    default:
+      // "Remind later" or dismissed — do not set done, will warn once more next session
       break;
   }
 }

--- a/src/misc.js
+++ b/src/misc.js
@@ -85,7 +85,6 @@ export async function warnAboutConflictedExtensions() {
         'vscode.open',
         vscode.Uri.parse('http://bit.ly/pio-vscode-conflicted-extensions'),
       );
-      extension.context.globalState.update(stateKey, { done: true });
       break;
     case 'Uninstall conflicted':
       conflicted.forEach((ext) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conflicted extensions warning from appearing repeatedly across sessions. When users take action on the warning (view more details or uninstall conflicted extensions), the warning state is now persisted to prevent duplicate prompts. Dismissing the warning still allows it to reappear in future sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->