### PR TITLE
remove clangd entrys from settings.json when switching to cpptools

### DIFF
--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -488,21 +488,29 @@ export async function ensureClangdArgs(projectDir) {
 
     // Remove clangd.path only when it points to an extension-managed binary
     const inspectedPath = config.inspect('path');
-    if (inspectedPath && inspectedPath.workspaceValue !== undefined) {
+    const workspacePath = inspectedPath?.workspaceValue;
+    if (typeof workspacePath === 'string') {
       const packagesDir = path.join(pioNodeHelpers.core.getCoreDir(), 'packages');
-      if (inspectedPath.workspaceValue.startsWith(packagesDir)) {
+      const relativePath = path.relative(packagesDir, workspacePath);
+      const isInsidePackages =
+        relativePath &&
+        relativePath !== '..' &&
+        !relativePath.startsWith(`..${path.sep}`) &&
+        !path.isAbsolute(relativePath);
+      if (isInsidePackages) {
         await config.update('path', undefined, vscode.ConfigurationTarget.Workspace);
       }
     }
 
     // Strip only --compile-commands-dir and --query-driver from arguments
     const inspectedArgs = config.inspect('arguments');
-    if (inspectedArgs && inspectedArgs.workspaceValue !== undefined) {
+    const workspaceArgs = inspectedArgs?.workspaceValue;
+    if (Array.isArray(workspaceArgs)) {
       const managed = ['--compile-commands-dir=', '--query-driver='];
-      const filtered = inspectedArgs.workspaceValue.filter(
-        (a) => !managed.some((prefix) => a.startsWith(prefix)),
+      const filtered = workspaceArgs.filter(
+        (a) => typeof a !== 'string' || !managed.some((prefix) => a.startsWith(prefix)),
       );
-      if (filtered.length !== inspectedArgs.workspaceValue.length) {
+      if (filtered.length !== workspaceArgs.length) {
         await config.update(
           'arguments',
           filtered.length ? filtered : undefined,

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -479,11 +479,23 @@ export async function ensureClangdConfig(projectDir) {
 }
 
 export async function ensureClangdArgs(projectDir) {
-  if (
-    getActiveBackendId() !== 'clangd' ||
-    !projectDir ||
-    !isBackendExtensionInstalled()
-  ) {
+  if (!projectDir) {
+    return;
+  }
+  // When cpptools is active, remove any leftover clangd workspace settings
+  if (getActiveBackendId() !== 'clangd') {
+    const config = vscode.workspace.getConfiguration('clangd');
+    const inspected = config.inspect('path');
+    if (inspected && inspected.workspaceValue !== undefined) {
+      await config.update('path', undefined, vscode.ConfigurationTarget.Workspace);
+    }
+    const inspectedArgs = config.inspect('arguments');
+    if (inspectedArgs && inspectedArgs.workspaceValue !== undefined) {
+      await config.update('arguments', undefined, vscode.ConfigurationTarget.Workspace);
+    }
+    return;
+  }
+  if (!isBackendExtensionInstalled()) {
     return;
   }
   const config = vscode.workspace.getConfiguration('clangd');

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -482,16 +482,33 @@ export async function ensureClangdArgs(projectDir) {
   if (!projectDir) {
     return;
   }
-  // When cpptools is active, remove any leftover clangd workspace settings
+  // When cpptools is active, strip only the flags this extension manages
   if (getActiveBackendId() !== 'clangd') {
     const config = vscode.workspace.getConfiguration('clangd');
-    const inspected = config.inspect('path');
-    if (inspected && inspected.workspaceValue !== undefined) {
-      await config.update('path', undefined, vscode.ConfigurationTarget.Workspace);
+
+    // Remove clangd.path only when it points to an extension-managed binary
+    const inspectedPath = config.inspect('path');
+    if (inspectedPath && inspectedPath.workspaceValue !== undefined) {
+      const packagesDir = path.join(pioNodeHelpers.core.getCoreDir(), 'packages');
+      if (inspectedPath.workspaceValue.startsWith(packagesDir)) {
+        await config.update('path', undefined, vscode.ConfigurationTarget.Workspace);
+      }
     }
+
+    // Strip only --compile-commands-dir and --query-driver from arguments
     const inspectedArgs = config.inspect('arguments');
     if (inspectedArgs && inspectedArgs.workspaceValue !== undefined) {
-      await config.update('arguments', undefined, vscode.ConfigurationTarget.Workspace);
+      const managed = ['--compile-commands-dir=', '--query-driver='];
+      const filtered = inspectedArgs.workspaceValue.filter(
+        (a) => !managed.some((prefix) => a.startsWith(prefix)),
+      );
+      if (filtered.length !== inspectedArgs.workspaceValue.length) {
+        await config.update(
+          'arguments',
+          filtered.length ? filtered : undefined,
+          vscode.ConfigurationTarget.Workspace,
+        );
+      }
     }
     return;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleaner handling of clangd-related workspace settings when using a different backend: stale clangd paths and specific clangd arguments are now removed to prevent conflicts.
  * Stops performing clangd configuration steps when no project is open, avoiding unintended changes to workspace settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->