### PR TITLE
clangd: add esp specific entrys to `.clangd`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the **pioarduino IDE** VSCode extension are documented in
 
 ---
 
+## [1.3.18] - 2026-04-20
+
+### ✨ New Features
+
+- **Espressif .clangd settings** — Smart .clangd updates that add missing compile/index settings without overwriting existing configuration.
+
+### 🐛 Bug Fixes
+- **clangd:** - Avoids unnecessary changes when required ESP or compile-flag entries already exist.
+- **clangd:** - Ensures observer-aware handling during index rebuilds so ESP settings are applied reliably.
+
+### 🔧 Tests
+- **clangd tokenizer:** - Added a lightweight test script to run shell-tokenization checks.
+
+---
+
 ## [1.3.17] - 2026-04-20
 
 ### 🐛 Bug Fixes

--- a/package.json
+++ b/package.json
@@ -883,6 +883,7 @@
   },
   "scripts": {
     "build": "webpack --mode production && vsce package",
+    "test": "node src/shellTokenize.test.js",
     "lint": "eslint .eslintrc.js src",
     "format": "prettier --single-quote --print-width 88 --write \"src/**/*.js\""
   },

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -443,17 +443,34 @@ async function findEspClangd() {
   return null;
 }
 
+// Flags that esp-clangd doesn't understand (ESP/GCC-specific machine flags).
+const ESP_CLANGD_REMOVE_FLAGS = [
+  '-misc-unused-parameters',
+  '-mfix-esp32-psram-cache-issue',
+  '-fno-shrink-wrap',
+  '-fno-tree-switch-conversion',
+  '-fstrict-volatile-bitfields',
+  '-free',
+  '-fipa-pta',
+  '-march=*',
+  '-mdisable-hardware-atomics',
+  '-mno-target-align',
+];
+
+const ESP_CLANGD_ADD_FLAGS = [
+  '-Wall',
+  '-Wextra',
+  '-Wunused-variable',
+  '-Wunused-function',
+  '-Wno-unused-parameter',
+  '-Wno-reserved-identifier',
+];
+
 /**
  * Ensure a .clangd config file exists in the project directory with
- * BuiltinHeaders: QueryDriver.
- *
- * By default clangd replaces the cross-compiler's built-in headers
- * (stddef.h, stdbool.h, etc.) with its own, which are built for the
- * host rather than the embedded target.  This causes false errors such
- * as "'stdbool.h' file not found" or libc++ vs libstdc++ mismatches.
- *
- * Setting BuiltinHeaders to QueryDriver tells clangd (≥ 21) to keep
- * the headers reported by --query-driver instead of substituting its own.
+ * BuiltinHeaders: QueryDriver and, when esp-clangd is used, the
+ * necessary Add/Remove flags for ESP-specific compiler options that
+ * upstream clangd does not understand.
  */
 export async function ensureClangdConfig(projectDir) {
   if (
@@ -464,6 +481,7 @@ export async function ensureClangdConfig(projectDir) {
     return;
   }
   const configPath = path.join(projectDir, '.clangd');
+  const useEspClangd = !!(await findEspClangd());
 
   let existing = '';
   try {
@@ -474,20 +492,51 @@ export async function ensureClangdConfig(projectDir) {
 
   const hasBuiltinHeaders = existing.includes('BuiltinHeaders');
   const hasSuppressDiag = existing.includes('pp_expects_filename');
+  const hasRemoveFlags = ESP_CLANGD_REMOVE_FLAGS.every((f) =>
+    existing.includes(f),
+  );
+  const hasAddFlags = ESP_CLANGD_ADD_FLAGS.every((f) => existing.includes(f));
+  const hasIndex = existing.includes('Background: Build');
 
-  // Already contains both directives – nothing to do
-  if (hasBuiltinHeaders && hasSuppressDiag) {
+  const needsEsp = useEspClangd && (!hasRemoveFlags || !hasAddFlags || !hasIndex);
+
+  // Already contains all required directives – nothing to do
+  if (hasBuiltinHeaders && hasSuppressDiag && !needsEsp) {
     return;
   }
 
   // Build only the missing parts
   const parts = [];
+
+  // CompileFlags block — collect all sub-keys into one block
+  const cfParts = [];
   if (!hasBuiltinHeaders) {
-    parts.push('CompileFlags:\n  BuiltinHeaders: QueryDriver');
+    cfParts.push('  BuiltinHeaders: QueryDriver');
   }
+  if (useEspClangd && !hasAddFlags) {
+    cfParts.push(
+      '  Add:',
+      ...ESP_CLANGD_ADD_FLAGS.map((f) => `    - "${f}"`),
+    );
+  }
+  if (useEspClangd && !hasRemoveFlags) {
+    cfParts.push(
+      '  Remove:',
+      ...ESP_CLANGD_REMOVE_FLAGS.map((f) => `    - "${f}"`),
+    );
+  }
+  if (cfParts.length > 0) {
+    parts.push('CompileFlags:\n' + cfParts.join('\n'));
+  }
+
   if (!hasSuppressDiag) {
     parts.push('Diagnostics:\n  Suppress: [pp_expects_filename]');
   }
+
+  if (useEspClangd && !hasIndex) {
+    parts.push('Index:\n  Background: Build\n  StandardLibrary: true');
+  }
+
   const block = parts.join('\n') + '\n';
 
   // Prepend the block (separated by ---) so we don't clobber user settings

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -488,7 +488,7 @@ async function isEspressifProject(projectDir, observer) {
       return false;
     }
     const platform = config.getEnvPlatform(env);
-    return typeof platform === 'string' && platform.startsWith('espressif');
+    return typeof platform === 'string' && /espressif|esp32|esp8266/i.test(platform);
   } catch {
     return false;
   }

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -447,6 +447,7 @@ async function findEspClangd() {
 const ESP_CLANGD_REMOVE_FLAGS = [
   '-misc-unused-parameters',
   '-mfix-esp32-psram-cache-issue',
+  '-mfix-esp32-psram-cache-strategy=*',
   '-fno-shrink-wrap',
   '-fno-tree-switch-conversion',
   '-fstrict-volatile-bitfields',
@@ -454,6 +455,8 @@ const ESP_CLANGD_REMOVE_FLAGS = [
   '-fipa-pta',
   '-march=*',
   '-mdisable-hardware-atomics',
+  '-mlongcalls',
+  '-mtext-section-literals',
   '-mtarget-align',
   '-mno-target-align',
 ];

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -473,7 +473,28 @@ const ESP_CLANGD_ADD_FLAGS = [
  * necessary Add/Remove flags for ESP-specific compiler options that
  * upstream clangd does not understand.
  */
-export async function ensureClangdConfig(projectDir) {
+/**
+ * Detect whether the active environment targets an Espressif platform
+ * by inspecting the platform field in platformio.ini via the observer.
+ */
+async function isEspressifProject(projectDir, observer) {
+  if (!observer) {
+    return false;
+  }
+  try {
+    const config = await observer.getConfig();
+    const env = await observer.revealActiveEnvironment();
+    if (!env) {
+      return false;
+    }
+    const platform = config.getEnvPlatform(env);
+    return typeof platform === 'string' && platform.startsWith('espressif');
+  } catch {
+    return false;
+  }
+}
+
+export async function ensureClangdConfig(projectDir, observer) {
   if (
     getActiveBackendId() !== 'clangd' ||
     !projectDir ||
@@ -482,7 +503,8 @@ export async function ensureClangdConfig(projectDir) {
     return;
   }
   const configPath = path.join(projectDir, '.clangd');
-  const useEspClangd = !!(await findEspClangd());
+  const espClangd = await findEspClangd();
+  const useEspFlags = !!espClangd && (await isEspressifProject(projectDir, observer));
 
   let existing = '';
   try {
@@ -495,9 +517,11 @@ export async function ensureClangdConfig(projectDir) {
   const hasSuppressDiag = existing.includes('pp_expects_filename');
   const hasRemoveFlags = ESP_CLANGD_REMOVE_FLAGS.every((f) => existing.includes(f));
   const hasAddFlags = ESP_CLANGD_ADD_FLAGS.every((f) => existing.includes(f));
-  const hasIndex = existing.includes('Background: Build');
+  // Respect any existing Index.Background entry (user may have set Skip, etc.)
+  const hasIndexBackground = /^Index:\s*\n(?:.*\n)*?\s+Background:/m.test(existing);
 
-  const needsEsp = useEspClangd && (!hasRemoveFlags || !hasAddFlags || !hasIndex);
+  const needsEsp =
+    useEspFlags && (!hasRemoveFlags || !hasAddFlags || !hasIndexBackground);
 
   // Already contains all required directives – nothing to do
   if (hasBuiltinHeaders && hasSuppressDiag && !needsEsp) {
@@ -512,10 +536,10 @@ export async function ensureClangdConfig(projectDir) {
   if (!hasBuiltinHeaders) {
     cfParts.push('  BuiltinHeaders: QueryDriver');
   }
-  if (useEspClangd && !hasAddFlags) {
+  if (useEspFlags && !hasAddFlags) {
     cfParts.push('  Add:', ...ESP_CLANGD_ADD_FLAGS.map((f) => `    - "${f}"`));
   }
-  if (useEspClangd && !hasRemoveFlags) {
+  if (useEspFlags && !hasRemoveFlags) {
     cfParts.push('  Remove:', ...ESP_CLANGD_REMOVE_FLAGS.map((f) => `    - "${f}"`));
   }
   if (cfParts.length > 0) {
@@ -526,7 +550,7 @@ export async function ensureClangdConfig(projectDir) {
     parts.push('Diagnostics:\n  Suppress: [pp_expects_filename]');
   }
 
-  if (useEspClangd && !hasIndex) {
+  if (useEspFlags && !hasIndexBackground) {
     parts.push('Index:\n  Background: Build\n  StandardLibrary: true');
   }
 

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -454,6 +454,7 @@ const ESP_CLANGD_REMOVE_FLAGS = [
   '-fipa-pta',
   '-march=*',
   '-mdisable-hardware-atomics',
+  '-mtarget-align',
   '-mno-target-align',
 ];
 

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -492,9 +492,7 @@ export async function ensureClangdConfig(projectDir) {
 
   const hasBuiltinHeaders = existing.includes('BuiltinHeaders');
   const hasSuppressDiag = existing.includes('pp_expects_filename');
-  const hasRemoveFlags = ESP_CLANGD_REMOVE_FLAGS.every((f) =>
-    existing.includes(f),
-  );
+  const hasRemoveFlags = ESP_CLANGD_REMOVE_FLAGS.every((f) => existing.includes(f));
   const hasAddFlags = ESP_CLANGD_ADD_FLAGS.every((f) => existing.includes(f));
   const hasIndex = existing.includes('Background: Build');
 
@@ -514,16 +512,10 @@ export async function ensureClangdConfig(projectDir) {
     cfParts.push('  BuiltinHeaders: QueryDriver');
   }
   if (useEspClangd && !hasAddFlags) {
-    cfParts.push(
-      '  Add:',
-      ...ESP_CLANGD_ADD_FLAGS.map((f) => `    - "${f}"`),
-    );
+    cfParts.push('  Add:', ...ESP_CLANGD_ADD_FLAGS.map((f) => `    - "${f}"`));
   }
   if (useEspClangd && !hasRemoveFlags) {
-    cfParts.push(
-      '  Remove:',
-      ...ESP_CLANGD_REMOVE_FLAGS.map((f) => `    - "${f}"`),
-    );
+    cfParts.push('  Remove:', ...ESP_CLANGD_REMOVE_FLAGS.map((f) => `    - "${f}"`));
   }
   if (cfParts.length > 0) {
     parts.push('CompileFlags:\n' + cfParts.join('\n'));

--- a/src/project/manager.js
+++ b/src/project/manager.js
@@ -98,7 +98,7 @@ export default class ProjectManager {
           const env = obs ? await obs.revealActiveEnvironment() : undefined;
           const envDir = env ? path.join(projectDir, '.pio', 'build', env) : undefined;
           await fixupCompileCommands(projectDir, envDir);
-          await ensureClangdConfig(projectDir);
+          await ensureClangdConfig(projectDir, obs);
           await ensureClangdArgs(projectDir, envDir);
           await ensureLaunchJson(projectDir);
           await notifyRescanBackend();


### PR DESCRIPTION
@coderabbitai analyze if all espressif gcc MCU specific flags are listed and added to file `.clangd` which clang does not know

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection of Espressif toolchain to augment project IntelliSense and indexing when appropriate.
  * Smarter .clangd updates that add missing compile/index settings without overwriting existing configuration.

* **Bug Fixes**
  * Avoids unnecessary changes when required ESP or compile-flag entries already exist.
  * Ensures observer-aware handling during index rebuilds so ESP settings are applied reliably.

* **Tests**
  * Added a lightweight test script to run shell-tokenization checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->