### PR TITLE
feature: treat .ino files as C++ and auto-include Arduino.h

### DIFF
--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -1380,8 +1380,24 @@ export async function ensureClangdConfig(projectDir, observer) {
   // .ino files are not in compile_commands.json (PIO converts them to .cpp at
   // build time).  Without an explicit language hint clangd cannot give them
   // IntelliSense.  Detect any user-supplied PathMatch for .ino so we don't
-  // override it.
-  const hasInoPathMatch = /PathMatch:\s*[^\n]*\\\.ino/.test(existing);
+  // override it.  .clangd is a multi-document YAML file (separated by `---`),
+  // so check each document independently and accept both the inline form
+  //   PathMatch: .*\.ino
+  // and the list form
+  //   PathMatch:
+  //     - .*\.ino
+  const hasInoPathMatch = existing.split(/^---\s*$/m).some((doc) => {
+    if (!/^\s*If\s*:/m.test(doc)) {
+      return false;
+    }
+    // Inline value:   PathMatch: <anything containing \.ino>
+    if (/PathMatch\s*:\s*[^\n]*\\\.ino/.test(doc)) {
+      return true;
+    }
+    // List form:  PathMatch:\n    - <item containing \.ino>\n ...
+    const listMatch = doc.match(/PathMatch\s*:\s*\n((?:\s*-\s*[^\n]*\n?)+)/);
+    return !!(listMatch && /\\\.ino/.test(listMatch[1]));
+  });
 
   const needsEsp =
     useEspFlags && (!hasRemoveFlags || !hasAddFlags || !hasIndexBackground);

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -1377,12 +1377,17 @@ export async function ensureClangdConfig(projectDir, observer) {
   const hasAddFlags = ESP_CLANGD_ADD_FLAGS.every((f) => existing.includes(f));
   // Respect any existing Index.Background entry (user may have set Skip, etc.)
   const hasIndexBackground = /^Index:\s*\n(?:.*\n)*?\s+Background:/m.test(existing);
+  // .ino files are not in compile_commands.json (PIO converts them to .cpp at
+  // build time).  Without an explicit language hint clangd cannot give them
+  // IntelliSense.  Detect any user-supplied PathMatch for .ino so we don't
+  // override it.
+  const hasInoPathMatch = /PathMatch:\s*[^\n]*\\\.ino/.test(existing);
 
   const needsEsp =
     useEspFlags && (!hasRemoveFlags || !hasAddFlags || !hasIndexBackground);
 
   // Already contains all required directives – nothing to do
-  if (hasBuiltinHeaders && hasSuppressDiag && !needsEsp) {
+  if (hasBuiltinHeaders && hasSuppressDiag && !needsEsp && hasInoPathMatch) {
     return;
   }
 
@@ -1412,7 +1417,29 @@ export async function ensureClangdConfig(projectDir, observer) {
     parts.push('Index:\n  Background: Build\n  StandardLibrary: true');
   }
 
-  const block = parts.join('\n') + '\n';
+  let block = parts.join('\n') + (parts.length ? '\n' : '');
+
+  // Treat .ino files as C++ and auto-include Arduino.h.  PIO preprocesses
+  // .ino → .cpp at build time, so .ino files never appear in
+  // compile_commands.json.  This conditional block lets clangd give them
+  // IntelliSense by inheriting include/define flags from neighbouring .cpp
+  // entries while supplying the language and the implicit Arduino.h include.
+  // It must live in its own YAML document (separated by `---`) because it
+  // uses an `If:` selector.
+  if (!hasInoPathMatch) {
+    const inoBlock =
+      [
+        'If:',
+        '  PathMatch: .*\\.ino',
+        'CompileFlags:',
+        '  Add:',
+        '    - "-x"',
+        '    - "c++"',
+        '    - "-include"',
+        '    - "Arduino.h"',
+      ].join('\n') + '\n';
+    block = block ? block + '---\n' + inoBlock : inoBlock;
+  }
 
   // Prepend the block (separated by ---) so we don't clobber user settings
   const content = existing ? block + '---\n' + existing : block;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Arduino `.ino` file configurations to better respect user settings
  * Automatic enablement of C++ parsing and Arduino library header inclusion for `.ino` files
  * Fixed string construction to eliminate unnecessary trailing newlines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->