### PR TITLE
Fix idf clangd

### DIFF
--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -261,9 +261,14 @@ export async function ensureCompileCommands(projectDir, observer, envDir) {
 
   // Check the processed clangd copy first – if it exists we are done.
   const clangdPath = path.join(projectDir, '.cache', 'clangd', 'compile_commands.json');
+  // Prefer the project-root compile_commands.json (produced by PIO/SCons
+  // `pio run -t compiledb`) over the CMake/ninja one in envDir.  For ESP-IDF
+  // projects the CMake DB only covers files actually built by CMake — project
+  // src/ files compiled by SCons end up with missing -I flags there, while
+  // the SCons-generated root DB has the complete set.
   const origCandidates = [
-    ...(envDir ? [path.join(envDir, 'compile_commands.json')] : []),
     path.join(projectDir, 'compile_commands.json'),
+    ...(envDir ? [path.join(envDir, 'compile_commands.json')] : []),
   ];
 
   let clangdStat = null;
@@ -923,30 +928,33 @@ export async function fixupCompileCommands(
   ) {
     return;
   }
-  // Read the original compile_commands.json – try the env build dir first
-  // (CMake / ninja output for Arduino-as-component / ESP-IDF projects), then
-  // fall back to project root (PIO compiledb output).  The original is never
-  // modified.
+  // Read the original compile_commands.json – prefer the project-root file
+  // produced by PIO/SCons (`pio run -t compiledb`) over the CMake/ninja one
+  // in envDir.  For ESP-IDF projects the CMake DB only covers files actually
+  // built by CMake; project src/ files compiled by SCons end up with missing
+  // -I flags there.  The SCons-generated root DB reflects the final build
+  // command line that actually compiled each file and thus has the complete
+  // include set.  The original file is never modified.
   const rootPath = path.join(projectDir, 'compile_commands.json');
   const envPath = envDir ? path.join(envDir, 'compile_commands.json') : undefined;
 
   let raw;
-  if (envPath) {
-    try {
-      raw = await fs.readFile(envPath, 'utf-8');
-    } catch {
-      // not found in envDir – try root
-    }
-  }
-  if (!raw && !allowRootFallback) {
-    return;
-  }
-  if (!raw) {
+  if (allowRootFallback) {
     try {
       raw = await fs.readFile(rootPath, 'utf-8');
     } catch {
-      return;
+      // not found at root – try envDir
     }
+  }
+  if (!raw && envPath) {
+    try {
+      raw = await fs.readFile(envPath, 'utf-8');
+    } catch {
+      // not found in envDir either
+    }
+  }
+  if (!raw) {
+    return;
   }
 
   let entries;
@@ -1541,19 +1549,22 @@ export function watchClangdCompileCommands(projectDir, onMissing) {
 }
 
 /**
- * Watch the CMake-generated compile_commands.json in envDir.
- * Calls onReady() whenever the file is created or changed (e.g. after a build).
+ * Watch the original compile_commands.json files for an IDF project.  Both the
+ * CMake-generated file in envDir AND the project-root file produced by PIO/SCons
+ * (`pio run -t compiledb`) are watched, because either may be the preferred
+ * source for clangd post-processing (root takes precedence — see fixupCompileCommands).
+ * Calls onReady() whenever either file is created or changed (e.g. after a build).
  */
 export function watchIdfCompileCommands(projectDir, envDir, onReady) {
   disposeIdfCcWatcher(projectDir);
-  if (!envDir) {
+  if (!projectDir && !envDir) {
     return;
   }
-  const pattern = new vscode.RelativePattern(envDir, 'compile_commands.json');
-  const watcher = vscode.workspace.createFileSystemWatcher(pattern);
-  const handler = async () => {
+  const disposables = [];
+
+  const makeHandler = (filePath) => async () => {
     try {
-      await fs.access(path.join(envDir, 'compile_commands.json'));
+      await fs.access(filePath);
       await onReady();
     } catch (err) {
       // file not yet accessible (will fire again when ready), or onReady threw
@@ -1562,9 +1573,36 @@ export function watchIdfCompileCommands(projectDir, envDir, onReady) {
       }
     }
   };
-  watcher.onDidCreate(handler);
-  watcher.onDidChange(handler);
-  _idfCcWatchers.set(path.normalize(projectDir), watcher);
+
+  if (envDir) {
+    const envFile = path.join(envDir, 'compile_commands.json');
+    const envWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(envDir, 'compile_commands.json'),
+    );
+    const envHandler = makeHandler(envFile);
+    envWatcher.onDidCreate(envHandler);
+    envWatcher.onDidChange(envHandler);
+    disposables.push(envWatcher);
+  }
+
+  if (projectDir) {
+    const rootFile = path.join(projectDir, 'compile_commands.json');
+    const rootWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(projectDir, 'compile_commands.json'),
+    );
+    const rootHandler = makeHandler(rootFile);
+    rootWatcher.onDidCreate(rootHandler);
+    rootWatcher.onDidChange(rootHandler);
+    disposables.push(rootWatcher);
+  }
+
+  _idfCcWatchers.set(path.normalize(projectDir || envDir), {
+    dispose() {
+      for (const d of disposables) {
+        d.dispose();
+      }
+    },
+  });
 }
 
 function _ensureIniWatcher(projectDir) {

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -1514,11 +1514,10 @@ export function watchClangdCompileCommands(projectDir, onMissing) {
 }
 
 /**
- * Watch the original compile_commands.json files for an IDF project.  Both the
- * CMake-generated file in envDir AND the project-root file produced by PIO/SCons
- * (`pio run -t compiledb`) are watched, because either may be the preferred
- * source for clangd post-processing (root takes precedence — see fixupCompileCommands).
- * Calls onReady() whenever either file is created or changed (e.g. after a build).
+ * Watch the compile_commands.json file for an IDF project.  Only the
+ * project-root file produced by PIO/SCons (`pio run -t compiledb`) is watched,
+ * because it is the preferred source for clangd post-processing.
+ * Calls onReady() whenever the file is created or changed (e.g. after a build).
  */
 export function watchIdfCompileCommands(projectDir, envDir, onReady) {
   disposeIdfCcWatcher(projectDir);
@@ -1596,11 +1595,6 @@ async function isIdfProjectByFilesystem(projectDir, envDir) {
 /**
  * Detect whether the active environment uses ESP-IDF — either as a standalone
  * framework or as the base for Arduino-as-a-component.
- *
- * For these project types the build system (CMake / Ninja) already generates
- * compile_commands.json natively, so pioarduino-vscode-ide must not trigger
- * `pio run --target compiledb`.  Post-processing (fixupCompileCommands) must
- * still run to copy/rewrite the CMake-generated file into .cache/clangd/.
  */
 export async function isIdfProject(observer, envDir) {
   if (!observer) {
@@ -1777,8 +1771,10 @@ export async function ensureClangdConfig(projectDir, observer) {
     parts.push('Diagnostics:\n  Suppress: [pp_expects_filename, unused-includes]');
   }
 
+  // Background indexing of large codebases crashes esp-clangd because
+  // too many burst parallel Cross Compiler calls. Use "Skip" until this is fixed.
   if (useEspFlags && !hasIndexBackground) {
-    parts.push('Index:\n  Background: Build\n  StandardLibrary: true');
+    parts.push('Index:\n  Background: Skip\n  StandardLibrary: true');
   }
 
   let block = parts.join('\n') + (parts.length ? '\n' : '');

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -258,6 +258,9 @@ export async function ensureCompileCommands(projectDir, observer, envDir) {
     return; // processed copy exists and no source DB was found
   }
   // No compile_commands.json at all – rebuild from scratch.
+  vscode.window.showInformationMessage(
+    'pioarduino: Build your ESP-IDF project first to generate compile_commands.json for clangd IntelliSense.',
+  );
   observer.rebuildIndex({ force: true });
 }
 
@@ -884,7 +887,6 @@ async function injectArduinoNewlibPlatformInclude(entries, packagesDir) {
 export async function fixupCompileCommands(
   projectDir,
   envDir,
-  { allowRootFallback = true } = {},
 ) {
   if (
     getActiveBackendId() !== 'clangd' ||
@@ -903,9 +905,7 @@ export async function fixupCompileCommands(
   const rootPath = path.join(projectDir, 'compile_commands.json');
   const envPath = envDir ? path.join(envDir, 'compile_commands.json') : undefined;
 
-  const rootStat = allowRootFallback
-    ? await fs.stat(rootPath).catch(() => null)
-    : null;
+  const rootStat = await fs.stat(rootPath).catch(() => null);
   const envStat = envPath ? await fs.stat(envPath).catch(() => null) : null;
   const sourcePath =
     rootStat && (!envStat || rootStat.mtimeMs >= envStat.mtimeMs)
@@ -1524,7 +1524,14 @@ export function watchIdfCompileCommands(projectDir, envDir, onReady) {
   }
   const disposables = [];
 
+  // Guard against double-firing: when both the root and envDir files change
+  // at nearly the same time (e.g. after a full build), only run onReady once.
+  let pending = false;
   const makeHandler = (filePath) => async () => {
+    if (pending) {
+      return;
+    }
+    pending = true;
     try {
       await fs.access(filePath);
       await onReady();
@@ -1533,6 +1540,8 @@ export function watchIdfCompileCommands(projectDir, envDir, onReady) {
       if (err && err.code !== 'ENOENT') {
         console.warn(`IDF compile_commands.json watcher: ${err.message || err}`);
       }
+    } finally {
+      pending = false;
     }
   };
 

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -217,47 +217,12 @@ export async function ensureCompileCommands(projectDir, observer, envDir) {
     return;
   }
 
-  // ESP-IDF and Arduino-as-component projects rely on CMake / Ninja to produce
-  // compile_commands.json.  Do not trigger `pio run --target compiledb` for
-  // these project types — the build system already owns that file.
-  if (await isIdfProject(observer, envDir)) {
-    const ccPath = envDir ? path.join(envDir, 'compile_commands.json') : null;
-
-    if (!ccPath) {
-      return; // envDir unknown — watcher in manager.js will handle it when build completes
-    }
-
-    let origStat = null;
-    try {
-      origStat = await fs.stat(ccPath);
-    } catch {
-      // File does not exist yet — user must build first.
-      vscode.window.showInformationMessage(
-        'Build your ESP-IDF project first to generate compile_commands.json for clangd IntelliSense. ' +
-          'IntelliSense will activate automatically after the build completes.',
-      );
-      return;
-    }
-
-    // Re-process only when the CMake output is newer than the clangd copy.
-    const clangdPath = path.join(
-      projectDir,
-      '.cache',
-      'clangd',
-      'compile_commands.json',
-    );
-    let clangdStat = null;
-    try {
-      clangdStat = await fs.stat(clangdPath);
-    } catch {
-      // clangd copy missing — process now
-    }
-
-    if (!clangdStat || origStat.mtimeMs > clangdStat.mtimeMs) {
-      await fixupCompileCommands(projectDir, envDir, { allowRootFallback: false });
-    }
-    return;
-  }
+  // For ESP-IDF projects, prefer the SCons-generated root file (created by
+  // `pio run -t compiledb`) over the CMake/Ninja envDir file: only the SCons
+  // version reflects the full set of include paths and flags actually applied
+  // when the source was compiled.  Fall back to the CMake file if the SCons
+  // one is not yet present (first build before compiledb finishes), and fall
+  // through to the rebuild path below if neither exists.
 
   // Check the processed clangd copy first – if it exists we are done.
   const clangdPath = path.join(projectDir, '.cache', 'clangd', 'compile_commands.json');

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -903,24 +903,22 @@ export async function fixupCompileCommands(
   const rootPath = path.join(projectDir, 'compile_commands.json');
   const envPath = envDir ? path.join(envDir, 'compile_commands.json') : undefined;
 
-  let raw;
-  if (allowRootFallback) {
-    try {
-      raw = await fs.readFile(rootPath, 'utf-8');
-    } catch {
-      // not found at root – try envDir
-    }
-  }
-  if (!raw && envPath) {
-    try {
-      raw = await fs.readFile(envPath, 'utf-8');
-    } catch {
-      // not found in envDir either
-    }
-  }
-  if (!raw) {
+  const rootStat = allowRootFallback
+    ? await fs.stat(rootPath).catch(() => null)
+    : null;
+  const envStat = envPath ? await fs.stat(envPath).catch(() => null) : null;
+  const sourcePath =
+    rootStat && (!envStat || rootStat.mtimeMs >= envStat.mtimeMs)
+      ? rootPath
+      : envStat
+        ? envPath
+        : null;
+
+  if (!sourcePath) {
     return;
   }
+
+  const raw = await fs.readFile(sourcePath, 'utf-8');
 
   let entries;
   try {
@@ -1538,15 +1536,24 @@ export function watchIdfCompileCommands(projectDir, envDir, onReady) {
     }
   };
 
-  if (projectDir) {
-    const rootFile = path.join(projectDir, 'compile_commands.json');
-    const rootWatcher = vscode.workspace.createFileSystemWatcher(
-      new vscode.RelativePattern(projectDir, 'compile_commands.json'),
+  const rootFile = path.join(projectDir, 'compile_commands.json');
+  const rootWatcher = vscode.workspace.createFileSystemWatcher(
+    new vscode.RelativePattern(projectDir, 'compile_commands.json'),
+  );
+  const rootHandler = makeHandler(rootFile);
+  rootWatcher.onDidCreate(rootHandler);
+  rootWatcher.onDidChange(rootHandler);
+  disposables.push(rootWatcher);
+
+  if (envDir) {
+    const envFile = path.join(envDir, 'compile_commands.json');
+    const envWatcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(envDir, 'compile_commands.json'),
     );
-    const rootHandler = makeHandler(rootFile);
-    rootWatcher.onDidCreate(rootHandler);
-    rootWatcher.onDidChange(rootHandler);
-    disposables.push(rootWatcher);
+    const envHandler = makeHandler(envFile);
+    envWatcher.onDidCreate(envHandler);
+    envWatcher.onDidChange(envHandler);
+    disposables.push(envWatcher);
   }
 
   _idfCcWatchers.set(path.normalize(projectDir), {

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -1522,7 +1522,7 @@ export function watchClangdCompileCommands(projectDir, onMissing) {
  */
 export function watchIdfCompileCommands(projectDir, envDir, onReady) {
   disposeIdfCcWatcher(projectDir);
-  if (!projectDir && !envDir) {
+  if (!projectDir) {
     return;
   }
   const disposables = [];
@@ -1539,17 +1539,6 @@ export function watchIdfCompileCommands(projectDir, envDir, onReady) {
     }
   };
 
-  if (envDir) {
-    const envFile = path.join(envDir, 'compile_commands.json');
-    const envWatcher = vscode.workspace.createFileSystemWatcher(
-      new vscode.RelativePattern(envDir, 'compile_commands.json'),
-    );
-    const envHandler = makeHandler(envFile);
-    envWatcher.onDidCreate(envHandler);
-    envWatcher.onDidChange(envHandler);
-    disposables.push(envWatcher);
-  }
-
   if (projectDir) {
     const rootFile = path.join(projectDir, 'compile_commands.json');
     const rootWatcher = vscode.workspace.createFileSystemWatcher(
@@ -1561,7 +1550,7 @@ export function watchIdfCompileCommands(projectDir, envDir, onReady) {
     disposables.push(rootWatcher);
   }
 
-  _idfCcWatchers.set(path.normalize(projectDir || envDir), {
+  _idfCcWatchers.set(path.normalize(projectDir), {
     dispose() {
       for (const d of disposables) {
         d.dispose();

--- a/src/intellisense.js
+++ b/src/intellisense.js
@@ -259,7 +259,7 @@ export async function ensureCompileCommands(projectDir, observer, envDir) {
   }
   // No compile_commands.json at all – rebuild from scratch.
   vscode.window.showInformationMessage(
-    'pioarduino: Build your ESP-IDF project first to generate compile_commands.json for clangd IntelliSense.',
+    'pioarduino: Build your project first to generate compile_commands.json for clangd IntelliSense.',
   );
   observer.rebuildIndex({ force: true });
 }
@@ -1512,9 +1512,10 @@ export function watchClangdCompileCommands(projectDir, onMissing) {
 }
 
 /**
- * Watch the compile_commands.json file for an IDF project.  Only the
- * project-root file produced by PIO/SCons (`pio run -t compiledb`) is watched,
- * because it is the preferred source for clangd post-processing.
+ * Watch compile_commands.json files for an IDF project.  Both the project-root
+ * file (produced by PIO/SCons `pio run -t compiledb`) and the envDir file
+ * (produced by CMake/Ninja) are watched, with the root file being the preferred
+ * source for clangd post-processing.
  * Calls onReady() whenever the file is created or changed (e.g. after a build).
  */
 export function watchIdfCompileCommands(projectDir, envDir, onReady) {

--- a/src/project/manager.js
+++ b/src/project/manager.js
@@ -44,23 +44,16 @@ export default class ProjectManager {
     this._configProvider = new ProjectConfigLanguageProvider();
     this._configChangedTimeout = undefined;
     this._activeProjectIsIdf = false; // sync flag updated on project switch
-    const self = this;
     const activeBackend = getActiveBackend();
 
-    const idfAwareBackend = {
-      ...activeBackend,
-      rebuildArgs(env) {
-        if (activeBackend.id === 'clangd' && self._activeProjectIsIdf) {
-          // Run a no-op PIO command for IDF — prevents compiledb while still
-          // triggering onDidRebuildIndex → fixupCompileCommands for the clangd cache.
-          return ['--version'];
-        }
-        return activeBackend.rebuildArgs(env);
-      },
-    };
+    // Always use the SCons `pio run -t compiledb` flow, including for IDF.
+    // CMake/Ninja's compile_commands.json is incomplete: SCons applies
+    // additional include paths and flags after CMake configuration, and only
+    // the SCons-generated root file reflects the final command line that
+    // actually compiled each source.
     this._pool = new pioNodeHelpers.project.ProjectPool({
       ide: activeBackend.indexerIde,
-      intelliSenseBackend: idfAwareBackend, // ← use wrapped backend
+      intelliSenseBackend: activeBackend,
       api: {
         logOutputChannel: this._logOutputChannel,
         createFileSystemWatcher: vscode.workspace.createFileSystemWatcher,
@@ -117,10 +110,7 @@ export default class ProjectManager {
           const env = obs ? await obs.revealActiveEnvironment() : undefined;
           const envDir = env ? path.join(projectDir, '.pio', 'build', env) : undefined;
 
-          const isIdf = await isIdfProject(obs, envDir);
-          await fixupCompileCommands(projectDir, envDir, {
-            allowRootFallback: !isIdf,
-          });
+          await fixupCompileCommands(projectDir, envDir);
           await ensureClangdConfig(projectDir, obs);
           await ensureClangdArgs(projectDir);
           await ensureLaunchJson(projectDir, env);
@@ -285,9 +275,7 @@ export default class ProjectManager {
       if (this._activeProjectIsIdf && selectedEnvDir) {
         watchIdfCompileCommands(projectDir, selectedEnvDir, async () => {
           try {
-            await fixupCompileCommands(projectDir, selectedEnvDir, {
-              allowRootFallback: false,
-            });
+            await fixupCompileCommands(projectDir, selectedEnvDir);
             await ensureClangdArgs(projectDir);
             await notifyRescanBackend();
           } catch (err) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Compilation database handling now consistently prefers project-root compile database, unifying behavior across project types.
  * Selection and processing of compile commands simplified; fallback logic removed for clearer, predictable outcomes.
  * Project watcher logic improved to avoid duplicate triggers when databases change and to dispose watchers cleanly.
  * If no suitable source DB exists and the processed copy is missing, the index is rebuilt automatically; background indexing for Espressif projects is now set to skip.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Jason2866/pioarduino-vscode-ide/pull/48)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->